### PR TITLE
Responds with 59 status code when requested URL has userinfo set

### DIFF
--- a/server.go
+++ b/server.go
@@ -106,6 +106,9 @@ func getRequestURL(conn io.Reader) (*url.URL, error) {
 	if err != nil {
 		return nil, fmt.Errorf("couldn't parse request URL")
 	}
+	if parsedURL.User != nil {
+		return nil, fmt.Errorf("userinfo not allowed in request URL")
+	}
 	if parsedURL.Scheme == "" {
 		// Default scheme is gemini
 		parsedURL.Scheme = "gemini"


### PR DESCRIPTION
As of specification version 0.14.1, URLs with a userinfo component are
not allowed. This patch chooses to return a bad request code instead of
simply stripping out userinfo to avoid any ambiguity.

closes #3