### PR TITLE
Support SSLKEYLOGFILE env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This fork of the library improves on the original in several ways, some listed a
 - Set default port and scheme for client requests
 - Raise error when META strings are too long in the response header
 - Supports new status code updates
+- If `SSLKEYLOGFILE` is set, session keys are written to the file in NSS format. This is useful for debugging TLS connections (but breaks security, so don't use unless necessary).
 
 ## License
 This library is under the ISC License, see the [LICENSE](./LICENSE) file for details.

--- a/client.go
+++ b/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -95,6 +96,15 @@ func (c *Client) connect(res *Response, host string, parsedURL *url.URL) (io.Rea
 	conf := &tls.Config{
 		MinVersion:         tls.VersionTLS12,
 		InsecureSkipVerify: true, // This must be set to allow self-signed certs
+	}
+
+	keylogfile := os.Getenv("SSLKEYLOGFILE")
+	if keylogfile != "" {
+		w, err := os.OpenFile(keylogfile, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
+		if err == nil {
+			conf.KeyLogWriter = w
+			defer w.Close()
+		}
 	}
 
 	conn, err := tls.DialWithDialer(&net.Dialer{Timeout: c.Timeout}, "tcp", host, conf)

--- a/server.go
+++ b/server.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"net/url"
+	"os"
 	"strings"
 )
 
@@ -53,6 +54,16 @@ func listen(addr, certFile, keyFile string) (net.Listener, error) {
 	}
 
 	config := &tls.Config{Certificates: []tls.Certificate{cer}}
+
+	keylogfile := os.Getenv("SSLKEYLOGFILE")
+	if keylogfile != "" {
+		w, err := os.OpenFile(keylogfile, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
+		if err == nil {
+			config.KeyLogWriter = w
+			defer w.Close()
+		}
+	}
+
 	ln, err := tls.Listen("tcp", addr, config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to listen: %v", err)


### PR DESCRIPTION
WRT my question on the mailing list, looks like this should allow logging TLS session keys. The code compiles and tests pass, but as something of a Go newbie I didn't know how to test this with gemget.

No need to merge this PR if it is badly written, but I'd love to see gemget support this.