### PR TITLE
Add SRV lookup

### DIFF
--- a/client.go
+++ b/client.go
@@ -9,7 +9,7 @@ import (
 	"net"
 	"net/url"
 	"os"
-  "sort"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -53,11 +53,11 @@ var DefaultClient = &Client{Timeout: 15 * time.Second}
 func getHost(parsedURL *url.URL) string {
 	host := parsedURL.Host
 	if parsedURL.Port() == "" {
-    port, target, err := checkSRV(host)
-    if err != nil {
-      port = "1965"
-      target = parsedURL.Hostname()
-    }
+		port, target, err := checkSRV(host)
+		if err != nil {
+			port = "1965"
+			target = parsedURL.Hostname()
+		}
 
 		host = net.JoinHostPort(target, port)
 	}
@@ -113,11 +113,11 @@ func (c *Client) FetchWithHostAndCert(host, rawURL string, certPEM, keyPEM []byt
 	// Add port to host if needed
 	_, _, err = net.SplitHostPort(host)
 	if err != nil {
-    port, target, err := checkSRV(host)
-    if err != nil {
-      port = "1965"
-      target = host
-    }
+		port, target, err := checkSRV(host)
+		if err != nil {
+			port = "1965"
+			target = host
+		}
 
 		// Error likely means there's no port in the host
 		host = net.JoinHostPort(target, port)
@@ -313,14 +313,14 @@ func readHeader(conn io.Reader) ([]byte, error) {
 }
 
 func checkSRV(host string) (string, string, error) {
-  _, srvs, err := net.LookupSRV("gemini", "tcp", host);
-  if err != nil {
-    return "", "", err;
-  }
+	_, srvs, err := net.LookupSRV("gemini", "tcp", host)
+	if err != nil {
+		return "", "", err
+	}
 
-  sort.Slice(srvs, func(a, b int) bool {
-    return srvs[a].Priority < srvs[b].Priority
-  })
+	sort.Slice(srvs, func(a, b int) bool {
+		return srvs[a].Priority < srvs[b].Priority
+	})
 
-  return strconv.FormatInt(int64(srvs[0].Port), 10), srvs[0].Target, nil
+	return strconv.FormatInt(int64(srvs[0].Port), 10), srvs[0].Target, nil
 }

--- a/client.go
+++ b/client.go
@@ -314,7 +314,7 @@ func readHeader(conn io.Reader) ([]byte, error) {
 
 func checkSRV(host string) (string, string, error) {
 	_, srvs, err := net.LookupSRV("gemini", "tcp", host)
-	if err != nil {
+	if err != nil || len(srvs) == 0 {
 		return "", "", err
 	}
 

--- a/client_test.go
+++ b/client_test.go
@@ -126,8 +126,8 @@ func TestGetHost(t *testing.T) {
 		{"[::1]:1965", "gemini://[::1]/test//"},
 		{"[::1]:123", "gemini://[::1]:123"},
 		{"[::1]:123", "gemini://[::1]:123/test//"},
-    // There's a dot at the end of the host since it absolute name which is returned by DNS
-    {"niedzwiedzinski.cyou.:20468", "gemini://niedzwiedzinski.cyou"},
+		// There's a dot at the end of the host since it absolute name which is returned by DNS
+		{"niedzwiedzinski.cyou.:20468", "gemini://niedzwiedzinski.cyou"},
 	}
 
 	for _, tc := range tests {

--- a/client_test.go
+++ b/client_test.go
@@ -126,6 +126,8 @@ func TestGetHost(t *testing.T) {
 		{"[::1]:1965", "gemini://[::1]/test//"},
 		{"[::1]:123", "gemini://[::1]:123"},
 		{"[::1]:123", "gemini://[::1]:123/test//"},
+    // There's a dot at the end of the host since it absolute name which is returned by DNS
+    {"niedzwiedzinski.cyou.:20468", "gemini://niedzwiedzinski.cyou"},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
I am setting up my own gemini server and noticed that amfora doesn't support [SRV DNS records](https://support.dnsimple.com/articles/srv-record/). Here I added a simple lookup that will check for SRV if no port is specified elsewhere it will use the default 1965.