### PR TITLE
Support for SOCKS5 proxies

### DIFF
--- a/client.go
+++ b/client.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/net/proxy"
 	"golang.org/x/net/idna"
 )
 
@@ -302,7 +303,7 @@ func (c *Client) connect(res *Response, host string, parsedURL *url.URL, clientC
 	}
 
 	// Dialer timeout for handshake
-	dialer := &net.Dialer{Timeout: c.ConnectTimeout}
+	dialer := proxy.FromEnvironmentUsing(&net.Dialer{Timeout: c.ConnectTimeout})
 	conn_notls, err := dialer.Dial("tcp", host)
 	if err != nil {
 		return conn_notls, err


### PR DESCRIPTION
This change allows clients to set the `all_proxy` environment variable to use a specified socks5 proxy for your connection.

When building `amfora` with this change, you can run:

```sh
$ all_proxy=socks5://127.0.0.1:9050 amfora gemini://...
```
to tunnel you connection via tor.

❗❗❗ BE AWARE❗❗❗ that just running `torsocks amfora` will only tunnel the dns request via the proxy. The actual connection will still go through directly, so you need to set the `all_proxy` variable as above.