### PR TITLE
fix(client): index out of range on malformed header

### DIFF
--- a/client.go
+++ b/client.go
@@ -418,7 +418,7 @@ func getHeader(conn io.Reader) (header, error) {
 	}
 
 	fields := strings.Fields(string(line))
-	if len(fields) < 2 && line[len(line)-1] != ' ' {
+	if len(fields) == 0 || (len(fields) < 2 && line[len(line)-1] != ' ') {
 		return header{}, fmt.Errorf("header not formatted correctly")
 	}
 

--- a/client_test.go
+++ b/client_test.go
@@ -101,6 +101,20 @@ func TestGetHeaderNoSpace(t *testing.T) {
 	}
 }
 
+func TestGetHeaderOnlyRN(t *testing.T) {
+	_, err := getHeader(strings.NewReader("\r\n"))
+	if err == nil {
+		t.Fatalf("expected to get an error for only \\r\\n header")
+	}
+}
+
+func TestGetHeaderWhitespaceAndRN(t *testing.T) {
+	_, err := getHeader(strings.NewReader(" \r\n"))
+	if err == nil {
+		t.Fatalf("expected to get an error for whitespace + \\r\\n header")
+	}
+}
+
 func parse(s string) *url.URL {
 	p, _ := url.Parse(s)
 	return p


### PR DESCRIPTION
So, long story short I got panic because of index out of range in `client.go`:

```sh
goroutine 15427668 [running]:
github.com/makeworld-the-better-one/go-gemini.getHeader({0x7fc1eec22b80?, 0x296e4df6e008?})
        /root/go/pkg/mod/github.com/makeworld-the-better-one/go-gemini@v0.13.1/client.go:421 +0x339
github.com/makeworld-the-better-one/go-gemini.getResponse(0x296e4d778840, {0x7fc1eec22b58, 0x296e4df6e008})
        /root/go/pkg/mod/github.com/makeworld-the-better-one/go-gemini@v0.13.1/client.go:402 +0x48
github.com/makeworld-the-better-one/go-gemini.(*Client).FetchWithHostAndCert(0x296e4cc86780, {0x296e52fd8c20, 0x19}, {0x296e4e5b47c0?, 0x7b08ff?}, {0x296e500ddf77, 0x0, 0x0}, {0x296e500ddf77, 0x0, ...})
        /root/go/pkg/mod/github.com/makeworld-the-better-one/go-gemini@v0.13.1/client.go:262 +0x879
github.com/makeworld-the-better-one/go-gemini.(*Client).FetchWithHost(...)
        /root/go/pkg/mod/github.com/makeworld-the-better-one/go-gemini@v0.13.1/client.go:175
github.com/makeworld-the-better-one/go-gemini.(*Client).Fetch(0x296e4cc86780, {0x296e4e5b47c0, 0x39})
        /root/go/pkg/mod/github.com/makeworld-the-better-one/go-gemini@v0.13.1/client.go:167 +0xf1
```

I think this should fix it. Just added `len(fields) == 0` check into there and added 2 small tests. Unfortunately due to complete lack of logs I don't know which capsule actually triggered that.